### PR TITLE
Fix Linux install validation false negatives for parenthesized headings

### DIFF
--- a/sync-skills.sh
+++ b/sync-skills.sh
@@ -2550,7 +2550,7 @@ validate_codex_skill_dir() {
                 print_error "Reviewer skill is missing enforced structure or layered-testing guidance"
                 return 1
             fi
-            if ! markdown_section_contains_all_patterns "$skill_dir/SKILL.md" "7. Language-Specific Quality Gates \\(CRITICAL\\)" "black --check" "ruff check" "mypy" "Import Linter" "circular import" "import safety" "prettier --check" "pass" "blocked"; then
+            if ! markdown_section_contains_all_patterns "$skill_dir/SKILL.md" "7. Language-Specific Quality Gates (CRITICAL)" "black --check" "ruff check" "mypy" "Import Linter" "circular import" "import safety" "prettier --check" "pass" "blocked"; then
                 print_error "Reviewer skill is missing language-specific formatter, typing, import-safety, or reporting gates"
                 return 1
             fi
@@ -2558,7 +2558,7 @@ validate_codex_skill_dir() {
                 print_error "Reviewer skill is missing anti-junk entrypoint guidance"
                 return 1
             fi
-            if ! markdown_section_contains_all_patterns "$skill_dir/SKILL.md" "Multi-Agent Execution Pattern \(Completion-First\)" "main agent must verify" "send updated work back" "multiple parallel reviewer passes" "distinct purpose or workstream label"; then
+            if ! markdown_section_contains_all_patterns "$skill_dir/SKILL.md" "Multi-Agent Execution Pattern (Completion-First)" "main agent must verify" "send updated work back" "multiple parallel reviewer passes" "distinct purpose or workstream label"; then
                 print_error "Reviewer skill is missing multi-reviewer lane or re-review guidance"
                 return 1
             fi
@@ -2738,7 +2738,7 @@ validate_codex_skill_dir() {
                 print_error "Git skill keeps high-risk commands inside Essential Git Commands"
                 return 1
             fi
-            if ! markdown_section_contains_all_patterns "$skill_dir/SKILL.md" "High-Risk Operations \(Explicit User Approval Only\)" "explicit user approval" "git reset --hard" "git rebase -i"; then
+            if ! markdown_section_contains_all_patterns "$skill_dir/SKILL.md" "High-Risk Operations (Explicit User Approval Only)" "explicit user approval" "git reset --hard" "git rebase -i"; then
                 print_error "Git skill is missing explicit high-risk operation gating"
                 return 1
             fi

--- a/tests/test_skill_pack_contracts.py
+++ b/tests/test_skill_pack_contracts.py
@@ -2830,6 +2830,26 @@ Notes:
                 completed_process.stdout + completed_process.stderr,
             )
 
+    def test_repo_validation_accepts_literal_parenthesized_skill_headings(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            sourced_script_path = write_sync_script_without_main(temporary_path)
+
+            for skill_name in ("git-expert", "reviewer"):
+                command = (
+                    f'source "{sourced_script_path}"; '
+                    f'CODEX_SOURCE="{REPOSITORY_ROOT}"; '
+                    f'CODEX_TARGET="{temporary_path / ".codex"}"; '
+                    'mkdir -p "$CODEX_TARGET"; '
+                    f'validate_codex_skill_dir "$CODEX_SOURCE/{skill_name}"'
+                )
+                completed_process = run_bash(command)
+                self.assertEqual(
+                    0,
+                    completed_process.returncode,
+                    completed_process.stdout + completed_process.stderr,
+                )
+
     def test_local_home_agent_override_file_can_pin_fast_model_for_memory_writer(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary_path = Path(temporary_directory)


### PR DESCRIPTION
## Summary
- use literal heading names for validator section lookups that perform exact Markdown heading matches
- add regression coverage for the affected `git-expert` and `reviewer` skill validation path
- restore the Linux `sync-skills.sh install` flow that was failing during fast validation

## Validation
- `python3 -m unittest tests.test_skill_pack_contracts.SkillPackContractTests.test_repo_validation_accepts_literal_parenthesized_skill_headings tests.test_install_repair_contracts.InstallRepairContractTests.test_install_uses_full_sync_when_only_repo_managed_config_fragments_exist`
- clean Linux temp target: `bash ./sync-skills.sh install`
- follow-up status check: `bash ./sync-skills.sh status`

Fixes #1
